### PR TITLE
Update sink doc

### DIFF
--- a/docs/aws-lambda-sink.md
+++ b/docs/aws-lambda-sink.md
@@ -25,21 +25,27 @@ The [AWS Lambda](https://aws.amazon.com/lambda/) sink connector is a [Pulsar IO 
 
 ![](/docs/lambda-sink.png)
 
-# How to get 
+# How to get
 
-You can get the AWS Lambda sink connector using one of the following methods:
+This section describes how to build the AWS Lambda sink connector.
 
-- Download the NAR package from [here](https://github.com/streamnative/pulsar-io-aws-lambda/releases/download/v2.7.0/pulsar-io-aws-lambda-2.7.0.nar).
+## Work with Function Worker
+
+You can get the AWS Lambda sink connector using one of the following methods if you use [Pulsar Function Worker](https://pulsar.apache.org/docs/en/functions-worker/) to run connectors in a cluster.
+
+- Download the NAR package from [the download page](https://github.com/streamnative/pulsar-io-aws-lambda/releases/download/v{{connector:version}}/pulsar-io-google-pubsub-{{connector:version}}.nar).
 
 - Build it from the source code.
 
-  1. Clone the source code to your machine.
+To build the AWS Lambda sink connector from the source code, follow these steps.
+
+1. Clone the source code to your machine.
 
      ```bash
      git clone https://github.com/streamnative/pulsar-io-aws-lambda
      ```
 
-  2. Assume that `PULSAR_IO_AWS_LAMBDA_HOME` is the home directory for the `pulsar-io-aws-lambda` repo. Build the connector in the `${PULSAR_IO_AWS_LAMBDA_HOME}` directory.
+2. Build the connector in the `pulsar-io-aws-lambda` directory.
 
      ```bash
      mvn clean install -DskipTests
@@ -49,105 +55,160 @@ You can get the AWS Lambda sink connector using one of the following methods:
 
      ```bash
      ls target
-     pulsar-io-aws-lambda-2.7.0.nar
+     pulsar-io-aws-lambda-{{connector:version}}.nar
      ```
 
-# How to configure 
+## Work with Function Mesh
 
-Before using the AWS Lambda sink connector, you need to configure it.
+You can pull the AWS Lambda sink connector Docker image from [the Docker Hub](https://hub.docker.com/r/streamnative/pulsar-io-aws-lambda) if you use [Function Mesh](https://functionmesh.io/docs/connectors/run-connector) to run the connector.
 
-You can create a configuration file (JSON or YAML) to set the following properties.
+# How to configure
+
+Before using the AWS Lambda sink, you need to configure it. This table lists the properties and the descriptions.
 
 | Name | Type|Required | Default | Description
 |------|----------|----------|---------|-------------|
-| `awsEndpoint` |String| false | " " (empty string) | AWS Lambda end-point URL. It can be found at [here](https://docs.aws.amazon.com/general/latest/gr/lambda-service.html). |
-| `awsRegion` | String| true | " " (empty string) | Supported AWS region. For example, us-west-1, us-west-2. |
-| `awsCredentialPluginName` | String|false | " " (empty string) | Fully-qualified class name of implementation of `AwsCredentialProviderPlugin`. |
-| `awsCredentialPluginParam` | String|true | " " (empty string) | JSON parameter to initialize `AwsCredentialsProviderPlugin`. |
+| `awsEndpoint` |String| false | " " (empty string) | The AWS Lambda endpoint URL. It can be found at [AWS Lambda endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/lambda-service.html). |
+| `awsRegion` | String| true | " " (empty string) | The supported AWS region. For example, `us-west-1`, `us-west-2`. |
+| `awsCredentialPluginName` | String|false | " " (empty string) | The fully-qualified class name of the `AwsCredentialProviderPlugin` implementation. |
+| `awsCredentialPluginParam` | String|true | " " (empty string) | The JSON parameter to initialize `AwsCredentialsProviderPlugin`. |
 | `lambdaFunctionName` | String|true | " " (empty string) | The Lambda function that should be invoked by the messages. |
-| `synchronousInvocation` | Boolean|true | true | `true` means invoking a Lambda function synchronously. <br>`false` means invoking a Lambda function asynchronously. |
+| `synchronousInvocation` | Boolean|true | true | <br />- `true`: invoke a Lambda function synchronously. <br />- `false`: invoke a Lambda function asynchronously. |
+
+## Work with Function Worker
+
+You can create a configuration file (JSON or YAML) to set the properties if you use [Pulsar Function Worker](https://pulsar.apache.org/docs/en/functions-worker/) to run connectors in a cluster.
 
 **Example**
 
-* JSON 
+- JSON 
 
-   ```json
+  ```json
     {
-        "tenant": "public",
-        "namespace": "default",
-        "name": "aws-lambda-sink",
-        "inputs": [
-          "test-aws-lambda-topic"
-        ],
-        "archive": "connectors/pulsar-io-aws-lambda-2.7.0.nar",
-        "parallelism": 1,
-        "configs":
-        {
-            "awsEndpoint": "https://lambda.us-west-2.amazonaws.com",
-            "awsRegion": "us-west-2",
-            "lambdaFunctionName": "test-function",
-            "awsCredentialPluginName": "",
-            "awsCredentialPluginParam": '{"accessKey":"myKey","secretKey":"my-Secret"}',
-            "synchronousInvocation": true
-        }
+      "tenant": "public",
+      "namespace": "default",
+      "name": "aws-lambda-sink",
+      "inputs": [
+        "test-aws-lambda-topic"
+      ],
+      "archive": "connectors/pulsar-io-aws-lambda-{{connector:version}}.nar",
+      "parallelism": 1,
+      "configs":
+      {
+          "awsEndpoint": "https://lambda.us-west-2.amazonaws.com",
+          "awsRegion": "us-west-2",
+          "lambdaFunctionName": "test-function",
+          "awsCredentialPluginName": "",
+          "awsCredentialPluginParam": '{"accessKey":"myKey","secretKey":"my-Secret"}',
+          "synchronousInvocation": true
+      }
     }
     ```
 
-* YAML
+- YAML
 
    ```yaml
    tenant: "public"
    namespace: "default"
    name: "aws-lambda-sink"
    inputs: 
-      - "test-aws-lambda-topic"
-   archive: "connectors/pulsar-io-aws-lambda-2.7.0.nar"
+    - "test-aws-lambda-topic"
+   archive: "connectors/pulsar-io-aws-lambda-{{connector:version}}.nar"
    parallelism: 1
 
    configs:
-      awsEndpoint: "https://lambda.us-west-2.amazonaws.com"
-      awsRegion: "us-west-2"
-      lambdaFunctionName: "test-function"
-      awsCredentialPluginName: ""
-      awsCredentialPluginParam: '{"accessKey":"myKey","secretKey":"my-Secret"}'
-      synchronousInvocation: true
+    awsEndpoint: "https://lambda.us-west-2.amazonaws.com"
+    awsRegion: "us-west-2"
+    lambdaFunctionName: "test-function"
+    awsCredentialPluginName: ""
+    awsCredentialPluginParam: '{"accessKey":"myKey","secretKey":"my-Secret"}'
+    synchronousInvocation: true
     ```
+
+## Work with Function Mesh
+
+You can create a [CustomResourceDefinitions (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to create an AWS Lambda sink connector. Using CRD makes Function Mesh naturally integrate with the Kubernetes ecosystem. For more information about Pulsar sink CRD configurations, see [sink CRD configurations](https://functionmesh.io/docs/connectors/io-crd-config/sink-crd-config).
+
+You can define a CRD file (YAML) to set the properties as below.
+
+```yaml
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Sink
+metadata:
+  name: aws-lambda-sink-sample
+spec:
+  image: streamnative/pulsar-io-aws-lambda:{{connector:version}}
+  className: org.apache.pulsar.ecosystem.io.aws.lambda.AWSLambdaBytesSink
+  replicas: 1
+  input:
+    topics: 
+    - persistent://public/default/destination
+    typeClassName: “[B”
+  sinkConfig:
+    awsEndpoint: "https://lambda.us.us-west-2.amazonaws.com"
+    awsRegion: "us-west-2"
+    lambdaFunctionName: "test-function"
+    awsCredentialPluginName: ""
+    awsCredentialPluginParam: '{"accessKey":"myKey","secretKey":"my-Secret"}'
+    synchronousInvocation: true
+  pulsar:
+    pulsarConfig: "test-pulsar-sink-config"
+  resources:
+    limits:
+    cpu: "0.2"
+    memory: 1.1G
+    requests:
+    cpu: "0.1"
+    memory: 1G
+  java:
+    jar: connectors/pulsar-io-aws-lambda-{{connector:version}}.nar
+  clusterName: test-pulsar
+  autoAck: true
+```
 
 # How to use
 
-You can use the AWS Lambda sink connector as a non built-in connector or a built-in connector as below. 
+You can use the AWS Lambda sink connector with Function Worker or Function Mesh.
 
-## Use as non built-in connector 
+## Work with Function Worker
+
+You can use the AWS Lambda sink connector as a non built-in connector or a built-in connector.
+
+::: tabs
+
+@@@ Use it as non built-in connector
 
 If you already have a Pulsar cluster, you can use the AWS Lambda sink connector as a non built-in connector directly.
 
-This example shows how to create an AWS Lambda sink connector on a Pulsar cluster using the [`pulsar-admin sinks create`](http://pulsar.apache.org/tools/pulsar-admin/2.8.0-SNAPSHOT/#-em-create-em--24) command.
+This example shows how to create an AWS Lambda sink connector on a Pulsar cluster using the [`pulsar-admin sinks create`](http://pulsar.apache.org/tools/pulsar-admin/2.10.0-SNAPSHOT/#-em-create-em--24) command.
 
-```
+```bash
 PULSAR_HOME/bin/pulsar-admin sinks create \
---archive pulsar-io-aws-lambda-2.7.0.nar \
+--archive pulsar-io-aws-lambda-{{connector:version}}.nar \
 --sink-config-file aws-lambda-sink-config.yaml \
 --classname org.apache.pulsar.ecosystem.io.aws.lambda.AWSLambdaBytesSink \
 --name aws-lambda-sink
 ```
 
-## Use as built-in connector
+@@@
 
-You can make the AWS Lambda sink connector as a built-in connector and use it on a standalone cluster, on-premises cluster, or K8S cluster.
+@@@ Use it as built-in connector
+
+You can make the AWS Lambda sink connector as a built-in connector and use it on a standalone cluster or an on-premises cluster.
 
 ### Standalone cluster
 
-This example describes how to use the AWS Lambda sink connector to pull data from Pulsar topics and persist data to AWS Lambda in standalone mode.
+This example describes how to use the AWS Lambda sink connector to pull messages from Pulsar topics and persist the messages to AWS Lambda to invoke Lambda functions.
 
-
-1. Prepare AWS Lambda service. Make sure the Lambda function is ready to use. 
+1. Prepare AWS Lambda service. Make sure the Lambda function is ready to use.
  
     For more information, see [Getting Started with Amazon AWS Lambda](https://aws.amazon.com/lambda/getting-started/).
 
 2. Copy the NAR package of the AWS Lambda connector to the Pulsar connectors directory.
 
     ```
-    cp pulsar-io-aws-lambda-2.7.0.nar PULSAR_HOME/connectors/pulsar-io-aws-lambda-2.7.0.nar
+    cp pulsar-io-aws-lambda-{{connector:version}}.nar 
+    PULSAR_HOME/connectors/pulsar-io-aws-lambda-{{connector:version}}.nar
     ```
 
 3. Start Pulsar in standalone mode.
@@ -181,7 +242,8 @@ This example explains how to create an AWS Lambda sink connector in an on-premis
 1. Copy the NAR package of the AWS Lambda connector to the Pulsar connectors directory.
 
     ```
-    cp pulsar-io-aws-lambda-2.7.0.nar $PULSAR_HOME/connectors/pulsar-io-aws-lambda-2.7.0.nar
+    cp pulsar-io-aws-lambda-{{connector:version}}.nar     
+    PULSAR_HOME/connectors/pulsar-io-aws-lambda-{{connector:version}}.nar
     ```
 
 2. Reload all [built-in connectors](https://pulsar.apache.org/docs/en/next/io-connectors/).
@@ -196,7 +258,7 @@ This example explains how to create an AWS Lambda sink connector in an on-premis
     PULSAR_HOME/bin/pulsar-admin sinks available-sinks
     ```
 
-4. Create an AWS Lambda sink connector on a Pulsar cluster using the [`pulsar-admin sinks create`](http://pulsar.apache.org/tools/pulsar-admin/2.8.0-SNAPSHOT/#-em-create-em--24) command.
+4. Create an AWS Lambda sink connector on a Pulsar cluster using the [`pulsar-admin sinks create`](http://pulsar.apache.org/tools/pulsar-admin/2.10.0-SNAPSHOT/#-em-create-em--24) command.
 
     ```
     PULSAR_HOME/bin/pulsar-admin sinks create \
@@ -205,41 +267,90 @@ This example explains how to create an AWS Lambda sink connector in an on-premis
     --name aws-lambda-sink
     ```
 
-### K8S cluster
+@@@
 
-1. Build a new image based on the Pulsar image with the AWS Lambda sink connector and push the new image to your image registry. This example tags the new image as `streamnative/pulsar-aws-lambda:2.7.0`.
+:::
 
-    ```Dockerfile
-    FROM apachepulsar/pulsar-all:2.7.0
-    RUN curl https://github.com/streamnative/pulsar-io-aws-lambda/releases/download/v2.7.0/pulsar-io-aws-lambda-2.7.0.nar -o /pulsar/connectors/pulsar-io-aws-lambda-2.7.0.nar
+## Work with Function Mesh
+
+This example describes how to create an AWS Lambda sink connector for a Kuberbetes cluster using Function Mesh.
+
+### Prerequisites
+
+- Create and connect to a [Kubernetes cluster](https://kubernetes.io/).
+
+- Create a [Pulsar cluster](https://pulsar.apache.org/docs/en/kubernetes-helm/) in the Kubernetes cluster.
+
+- [Install the Function Mesh Operator and CRD](https://functionmesh.io/docs/install-function-mesh/) into the Kubernetes cluster.
+
+### Step
+
+1. Define the AWS Lambda sink connector with a YAML file and save it as `sink-sample.yaml`.
+
+    This example shows how to publish the AWS Lambda sink connector to Function Mesh with a Docker image.
+
+    ```yaml
+    apiVersion: compute.functionmesh.io/v1alpha1
+    kind: Sink
+    metadata:
+      name: aws-lambda-sink-sample
+    spec:
+      image: streamnative/pulsar-io-aws-lambda:{{connector:version}}
+      className: org.apache.pulsar.ecosystem.io.aws.lambda.AWSLambdaBytesSink
+      replicas: 1
+      input:
+        topics: 
+        - persistent://public/default/destination
+        typeClassName: “[B”
+      sinkConfig:
+        awsEndpoint: "https://lambda.us.us-west-2.amazonaws.com"
+        awsRegion: "us-west-2"
+        lambdaFunctionName: "test-function"
+        awsCredentialPluginName: ""
+        awsCredentialPluginParam: '{"accessKey":"myKey","secretKey":"my-Secret"}'
+        synchronousInvocation: true
+      pulsar:
+        pulsarConfig: "test-pulsar-sink-config"
+      resources:
+        limits:
+        cpu: "0.2"
+        memory: 1.1G
+        requests:
+        cpu: "0.1"
+        memory: 1G
+      java:
+        jar: connectors/pulsar-io-aws-lambda-{{connector:version}}.nar
+      clusterName: test-pulsar
+      autoAck: true
     ```
 
-2. Extract the previous `--set` arguments from K8S to the `pulsar.yaml` file.
+2. Apply the YAML file to create the AWS Lambda sink connector.
+
+    **Input**
 
     ```
-    helm get values <release-name> > pulsar.yaml
+    kubectl apply -f <path-to-sink-sample.yaml>
     ```
 
-3. Replace the `images` section in the `pulsar.yaml` file with the `images` section of `streamnative/pulsar-aws-lambda:2.7.0`.
-
-4. Upgrade the K8S cluster with the `pulsar.yaml`  file.
+    **Output**
 
     ```
-    helm upgrade <release-name> streamnative/pulsar \
-        --version <new version> \
-        -f pulsar.yaml
+    sink.compute.functionmesh.io/aws-lambda-sink-sample created
     ```
 
-    > **Tip**
-    >
-    > For more information about how to upgrade a Pulsar cluster with Helm, see [Upgrade Guide](https://docs.streamnative.io/platform/latest/install-and-upgrade/helm/install/upgrade).
+3. Check whether the AWS Lambda sink connector is created successfully.
 
-
-5. Create a AWS Lambda sink connector on a Pulsar cluster using the [`pulsar-admin sinks create`](http://pulsar.apache.org/tools/pulsar-admin/2.8.0-SNAPSHOT/#-em-create-em--24) command.
+    **Input**
 
     ```
-    PULSAR_HOME/bin/pulsar-admin sinks create \
-    --sink-type aws-lambda \
-    --sink-config-file aws-lambda-sink-config.yaml \
-    --name aws-lambda-sink
+    kubectl get all
     ```
+
+    **Output**
+
+    ```
+    NAME                                         READY   STATUS      RESTARTS   AGE
+    pod/aws-lambda-sink-sample-0               1/1    Running     0          77s
+    ```
+
+    After that, you can use the AWS Lambda sink connector to export Pulsar messages to AWS Lambda to invoke Lambda functions.


### PR DESCRIPTION

### Motivation

The lambda sink connector can be submitted to a K8S cluster through Function Mesh. Therefore, update the doc accordingly.

### Modifications

Add contents about how to get, configure and work the Lambda sink connector using Function Mesh.



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ x ] `doc` 
  
  (If this PR contains doc changes)

